### PR TITLE
Fix incorrect strcmp() return value check

### DIFF
--- a/native/lib/viv_hook.c
+++ b/native/lib/viv_hook.c
@@ -82,7 +82,7 @@ int my_open(const char* path, int flags, ...)
         ret = open(path, flags);
     }
     
-    if(ret >= 0 && (!strcmp(path, "/dev/galcore") || !strcmp(path, "/dev/graphics/galcore") == 0))
+    if(ret >= 0 && (!strcmp(path, "/dev/galcore") || !strcmp(path, "/dev/graphics/galcore")))
     {
         _galcore_handle = ret;
         printf("opened galcore: %i\n", ret);


### PR DESCRIPTION
It seems like the check for when `path` is `/dev/graphics/galcore` is inverted from what it should be.
