### PR TITLE
fix linking error with "undefined reference to pthread" on a clean compile

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -17,6 +17,6 @@ COMMON_FLAGS = -O2 -g3 -ggdb3 -Wall -Wmissing-prototypes -DGCABI_${GCABI} $(GCC_
           -Werror=return-type
 
 CFLAGS += $(PLATFORM_CFLAGS) $(COMMON_FLAGS) -std=gnu99
-CXXFLAGS += $(PLATFORM_CXXFLAGS) $(COMMON_FLAGS)
+CXXFLAGS += $(PLATFORM_CXXFLAGS) $(COMMON_FLAGS) -pthread
 LDFLAGS += $(PLATFORM_LDFLAGS) $(COMMON_FLAGS) -pthread -lm
 


### PR DESCRIPTION
When I tried to compile/link the code on my system I had some errors concerning pthreads. This change worked for me.
