### PR TITLE
rnndb: document MMU exception interrupt bit

### DIFF
--- a/rnndb/state_hi.xml
+++ b/rnndb/state_hi.xml
@@ -83,7 +83,8 @@ xsi:schemaLocation="http://nouveau.freedesktop.org/ rules-ng.xsd">
             <bitfield high="9" low="9" name="DET_RD_ERR"/>
         </reg32>
         <reg32 offset="0x00010" name="INTR_ACKNOWLEDGE" brief="Interrupt acknowledge register">
-            <bitfield high="30" low="0" name="INTR_VEC" brief="Event signal interrupt bits"/>
+            <bitfield high="29" low="0" name="INTR_VEC" brief="Event signal interrupt bits"/>
+            <bitfield pos="30" name="MMU_EXCEPTION" brief="MMU exception interrupt"/>
             <bitfield pos="31" name="AXI_BUS_ERROR" brief="AXI bus error interrupt"/>
             <doc>Each bit represents a corresponding event being triggered.
                 Reading this register clears the interrupt flags.</doc>

--- a/src/etnaviv/cmdstream.xml.h
+++ b/src/etnaviv/cmdstream.xml.h
@@ -8,9 +8,9 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- cmdstream.xml (  12621 bytes, from 2016-09-04 14:31:43)
-- copyright.xml (   1597 bytes, from 2016-09-03 18:17:46)
-- common.xml    (  20583 bytes, from 2016-09-03 17:54:32)
+- cmdstream.xml (  12621 bytes, from 2016-09-06 14:44:16)
+- copyright.xml (   1597 bytes, from 2016-09-06 14:44:16)
+- common.xml    (  20583 bytes, from 2016-09-06 14:14:12)
 
 Copyright (C) 2012-2016 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>

--- a/src/etnaviv/common.xml.h
+++ b/src/etnaviv/common.xml.h
@@ -8,13 +8,13 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- state.xml     (  18940 bytes, from 2016-09-03 18:19:59)
-- common.xml    (  20583 bytes, from 2016-09-03 17:54:32)
-- state_hi.xml  (  25567 bytes, from 2016-09-03 18:19:31)
-- copyright.xml (   1597 bytes, from 2016-09-03 18:17:46)
-- state_2d.xml  (  51552 bytes, from 2016-09-03 18:13:23)
-- state_3d.xml  (  54603 bytes, from 2016-09-03 18:19:05)
-- state_vg.xml  (   5975 bytes, from 2016-09-03 18:19:40)
+- state.xml     (  18940 bytes, from 2016-09-06 14:14:12)
+- common.xml    (  20583 bytes, from 2016-09-06 14:14:12)
+- state_hi.xml  (  25653 bytes, from 2016-09-06 14:45:17)
+- copyright.xml (   1597 bytes, from 2016-09-06 14:44:16)
+- state_2d.xml  (  51552 bytes, from 2016-09-06 14:44:16)
+- state_3d.xml  (  54603 bytes, from 2016-09-06 14:44:16)
+- state_vg.xml  (   5975 bytes, from 2016-09-06 14:44:16)
 
 Copyright (C) 2012-2016 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>

--- a/src/etnaviv/isa.xml.h
+++ b/src/etnaviv/isa.xml.h
@@ -8,8 +8,8 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- isa.xml       (  19227 bytes, from 2016-09-03 18:19:20)
-- copyright.xml (   1597 bytes, from 2016-09-03 18:17:46)
+- isa.xml       (  19227 bytes, from 2016-09-06 14:44:16)
+- copyright.xml (   1597 bytes, from 2016-09-06 14:44:16)
 
 Copyright (C) 2012-2016 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>

--- a/src/etnaviv/state.xml.h
+++ b/src/etnaviv/state.xml.h
@@ -8,13 +8,13 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- state.xml     (  18940 bytes, from 2016-09-03 18:19:59)
-- common.xml    (  20583 bytes, from 2016-09-03 17:54:32)
-- state_hi.xml  (  25567 bytes, from 2016-09-03 18:19:31)
-- copyright.xml (   1597 bytes, from 2016-09-03 18:17:46)
-- state_2d.xml  (  51552 bytes, from 2016-09-03 18:13:23)
-- state_3d.xml  (  54603 bytes, from 2016-09-03 18:19:05)
-- state_vg.xml  (   5975 bytes, from 2016-09-03 18:19:40)
+- state.xml     (  18940 bytes, from 2016-09-06 14:14:12)
+- common.xml    (  20583 bytes, from 2016-09-06 14:14:12)
+- state_hi.xml  (  25653 bytes, from 2016-09-06 14:45:17)
+- copyright.xml (   1597 bytes, from 2016-09-06 14:44:16)
+- state_2d.xml  (  51552 bytes, from 2016-09-06 14:44:16)
+- state_3d.xml  (  54603 bytes, from 2016-09-06 14:44:16)
+- state_vg.xml  (   5975 bytes, from 2016-09-06 14:44:16)
 
 Copyright (C) 2012-2016 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>

--- a/src/etnaviv/state_2d.xml.h
+++ b/src/etnaviv/state_2d.xml.h
@@ -8,13 +8,13 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- state.xml     (  18940 bytes, from 2016-09-03 18:19:59)
-- common.xml    (  20583 bytes, from 2016-09-03 17:54:32)
-- state_hi.xml  (  25567 bytes, from 2016-09-03 18:19:31)
-- copyright.xml (   1597 bytes, from 2016-09-03 18:17:46)
-- state_2d.xml  (  51552 bytes, from 2016-09-03 18:13:23)
-- state_3d.xml  (  54603 bytes, from 2016-09-03 18:19:05)
-- state_vg.xml  (   5975 bytes, from 2016-09-03 18:19:40)
+- state.xml     (  18940 bytes, from 2016-09-06 14:14:12)
+- common.xml    (  20583 bytes, from 2016-09-06 14:14:12)
+- state_hi.xml  (  25653 bytes, from 2016-09-06 14:45:17)
+- copyright.xml (   1597 bytes, from 2016-09-06 14:44:16)
+- state_2d.xml  (  51552 bytes, from 2016-09-06 14:44:16)
+- state_3d.xml  (  54603 bytes, from 2016-09-06 14:44:16)
+- state_vg.xml  (   5975 bytes, from 2016-09-06 14:44:16)
 
 Copyright (C) 2012-2016 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>

--- a/src/etnaviv/state_3d.xml.h
+++ b/src/etnaviv/state_3d.xml.h
@@ -8,13 +8,13 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- state.xml     (  18940 bytes, from 2016-09-03 18:19:59)
-- common.xml    (  20583 bytes, from 2016-09-03 17:54:32)
-- state_hi.xml  (  25567 bytes, from 2016-09-03 18:19:31)
-- copyright.xml (   1597 bytes, from 2016-09-03 18:17:46)
-- state_2d.xml  (  51552 bytes, from 2016-09-03 18:13:23)
-- state_3d.xml  (  54603 bytes, from 2016-09-03 18:19:05)
-- state_vg.xml  (   5975 bytes, from 2016-09-03 18:19:40)
+- state.xml     (  18940 bytes, from 2016-09-06 14:14:12)
+- common.xml    (  20583 bytes, from 2016-09-06 14:14:12)
+- state_hi.xml  (  25653 bytes, from 2016-09-06 14:45:17)
+- copyright.xml (   1597 bytes, from 2016-09-06 14:44:16)
+- state_2d.xml  (  51552 bytes, from 2016-09-06 14:44:16)
+- state_3d.xml  (  54603 bytes, from 2016-09-06 14:44:16)
+- state_vg.xml  (   5975 bytes, from 2016-09-06 14:44:16)
 
 Copyright (C) 2012-2016 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>

--- a/src/etnaviv/state_hi.xml.h
+++ b/src/etnaviv/state_hi.xml.h
@@ -8,13 +8,13 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- state.xml     (  18940 bytes, from 2016-09-03 18:19:59)
-- common.xml    (  20583 bytes, from 2016-09-03 17:54:32)
-- state_hi.xml  (  25567 bytes, from 2016-09-03 18:19:31)
-- copyright.xml (   1597 bytes, from 2016-09-03 18:17:46)
-- state_2d.xml  (  51552 bytes, from 2016-09-03 18:13:23)
-- state_3d.xml  (  54603 bytes, from 2016-09-03 18:19:05)
-- state_vg.xml  (   5975 bytes, from 2016-09-03 18:19:40)
+- state.xml     (  18940 bytes, from 2016-09-06 14:14:12)
+- common.xml    (  20583 bytes, from 2016-09-06 14:14:12)
+- state_hi.xml  (  25653 bytes, from 2016-09-06 14:45:17)
+- copyright.xml (   1597 bytes, from 2016-09-06 14:44:16)
+- state_2d.xml  (  51552 bytes, from 2016-09-06 14:44:16)
+- state_3d.xml  (  54603 bytes, from 2016-09-06 14:44:16)
+- state_vg.xml  (   5975 bytes, from 2016-09-06 14:44:16)
 
 Copyright (C) 2012-2016 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>
@@ -106,9 +106,10 @@ DEALINGS IN THE SOFTWARE.
 #define VIVS_HI_AXI_STATUS_DET_RD_ERR				0x00000200
 
 #define VIVS_HI_INTR_ACKNOWLEDGE				0x00000010
-#define VIVS_HI_INTR_ACKNOWLEDGE_INTR_VEC__MASK			0x7fffffff
+#define VIVS_HI_INTR_ACKNOWLEDGE_INTR_VEC__MASK			0x3fffffff
 #define VIVS_HI_INTR_ACKNOWLEDGE_INTR_VEC__SHIFT		0
 #define VIVS_HI_INTR_ACKNOWLEDGE_INTR_VEC(x)			(((x) << VIVS_HI_INTR_ACKNOWLEDGE_INTR_VEC__SHIFT) & VIVS_HI_INTR_ACKNOWLEDGE_INTR_VEC__MASK)
+#define VIVS_HI_INTR_ACKNOWLEDGE_MMU_EXCEPTION			0x40000000
 #define VIVS_HI_INTR_ACKNOWLEDGE_AXI_BUS_ERROR			0x80000000
 
 #define VIVS_HI_INTR_ENBL					0x00000014

--- a/src/etnaviv/state_vg.xml.h
+++ b/src/etnaviv/state_vg.xml.h
@@ -8,13 +8,13 @@ http://0x04.net/cgit/index.cgi/rules-ng-ng
 git clone git://0x04.net/rules-ng-ng
 
 The rules-ng-ng source files this header was generated from are:
-- state.xml     (  18940 bytes, from 2016-09-03 18:19:59)
-- common.xml    (  20583 bytes, from 2016-09-03 17:54:32)
-- state_hi.xml  (  25567 bytes, from 2016-09-03 18:19:31)
-- copyright.xml (   1597 bytes, from 2016-09-03 18:17:46)
-- state_2d.xml  (  51552 bytes, from 2016-09-03 18:13:23)
-- state_3d.xml  (  54603 bytes, from 2016-09-03 18:19:05)
-- state_vg.xml  (   5975 bytes, from 2016-09-03 18:19:40)
+- state.xml     (  18940 bytes, from 2016-09-06 14:14:12)
+- common.xml    (  20583 bytes, from 2016-09-06 14:14:12)
+- state_hi.xml  (  25653 bytes, from 2016-09-06 14:45:17)
+- copyright.xml (   1597 bytes, from 2016-09-06 14:44:16)
+- state_2d.xml  (  51552 bytes, from 2016-09-06 14:44:16)
+- state_3d.xml  (  54603 bytes, from 2016-09-06 14:44:16)
+- state_vg.xml  (   5975 bytes, from 2016-09-06 14:44:16)
 
 Copyright (C) 2012-2016 by the following authors:
 - Wladimir J. van der Laan <laanwj@gmail.com>


### PR DESCRIPTION
Document the MMU exception interrupt bit as found in galcore
kernel sources 5.0.11.p8.4. This is needed to support mmuv2
in the etnaviv kernel driver.

Signed-off-by: Christian Gmeiner <christian.gmeiner@gmail.com>