### PR TITLE
driver/etna_zsa.c: Fix build

### DIFF
--- a/attic/driver/etna_zsa.c
+++ b/attic/driver/etna_zsa.c
@@ -107,7 +107,7 @@ static void *etna_pipe_create_depth_stencil_alpha_state(struct pipe_context *pip
     cs->PE_STENCIL_CONFIG =
             translate_stencil_mode(dsa.stencil[0].enabled, dsa.stencil[1].enabled) |
             VIVS_PE_STENCIL_CONFIG_MASK_FRONT(dsa.stencil[0].valuemask) |
-            VIVS_PE_STENCIL_CONFIG_WRITE_MASK(dsa.stencil[0].writemask);
+            VIVS_PE_STENCIL_CONFIG_WRITE_MASK_FRONT(dsa.stencil[0].writemask);
             /* XXX back masks in VIVS_PE_DEPTH_CONFIG_EXT? */
             /* XXX VIVS_PE_STENCIL_CONFIG_REF_FRONT comes from pipe_stencil_ref */
 


### PR DESCRIPTION
Fix build.

VIVS_PE_STENCIL_CONFIG_WRITE_MASK-> VIVS_PE_STENCIL_CONFIG_WRITE_MASK_FRONT in attic/driver/etna_zsa.c